### PR TITLE
data-create

### DIFF
--- a/docs/data-create.rst
+++ b/docs/data-create.rst
@@ -121,11 +121,8 @@ Parameters of the feature extraction script can be adjusted to change the patch 
   --patchSize
     Patch size of each superpixel. Range is [8, 512] (default 128).
 
-  --usePCAmodel
-    'true' to use an existing transform for inference. Setting 'true' requires copying the existing .pkl file to the base directory and setting parameter 'inputPCAModel'. Setting 'false' generates a new PCA transformation with default filename 'pca_model_sample.pkl' in the base project folder (default 'false').
-
   --inputPCAModel
-    Path and filename of .pkl for PCA transformation as mounted in the data creation container.
+    Path and filename of .pkl for PCA transformation as mounted in the data creation container. example) --inputPCAModel /${PWD##*/}/pca_model_sample.pkl
 
   --projectName
     Name of the project directory. Default 'myproject'.

--- a/docs/data-create.rst
+++ b/docs/data-create.rst
@@ -132,7 +132,7 @@ Parameters of the feature extraction script can be adjusted to change the patch 
     Patch size of each superpixel. Range is [8, 512] (default 128).
 
   --inputPCAModel
-    Path and filename of .pkl when importing a PCA transform. This specifies the location of the .pkl as mounted inside the docker. If the .pkl file was copied to the current project then --inputPCAModel /${PWD##*/}/pca_model_sample.pkl. (default - blank - generate a new PCA transform).
+    Path and filename of .pkl when importing a PCA transform. This specifies the location of the .pkl as mounted inside the docker. If the .pkl file was copied to the current project then --inputPCAModel /${PWD##*/}/pca_model_sample.pkl.
 
   --projectName
     Name of the project directory (default - current working directory name).
@@ -143,7 +143,7 @@ An important note on training, inference, and the PCA transformation:
 .. note::  HistomicsML can be used to either train new classifiers, or to apply trained classifiers to new datasets (inference). When doing inference it is important that features are extracted in a consistent manner from the training dataset and new dataset.
 
   During feature extraction a principal component analysis (PCA) transformation is applied to the features to improve speed and performance. This transformation can either be generated from the newly extracted features or imported from an existing dataset. When generating datasets for inference the PCA transformation should be imported from the training dataset that was used to develop the classifier.
-  
+
   HistomicsML stores a PCA transformation as a .pkl file in the base project directory. These files should be managed and copied between directories as needed when performing inference or for re-use.
 
 


### PR DESCRIPTION
Dataset creation is updated.

/dataset directory inside the docker image is removed to avoid the confusion between the local machine and the docker image.

Instead, we find the name of the project directory using -v ${PWD##*/}.

Using this way, we can remove all paths which are unnecessary and create the slide information with the location of the tif images.

This update is closely related to other updates with creating multiple datasets under a master project folder.
