### PR TITLE
Added shell scripts for starting HistomicsML2

### DIFF
--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+redis-cli flushdb
+
+echo "==========================================="
+echo "== Redis server is successfully reloaded =="
+echo "==========================================="
+
+cd /var/www/html/predict-rest-api
+
+python run_model_server.py
+
+echo "===================================================="
+echo "== Model server is disconnected ===================="
+echo "== Run "./restart.sh" to restart the model server =="
+echo "===================================================="
+

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+docker pull cancerdatascience/histomicsml_db:example
+
+echo "========================================================="
+echo "== A container for the HistomicsML2 database is pulled =="
+echo "========================================================="
+
+docker pull cancerdatascience/histomicsml:example
+
+echo "==========================================================="
+echo "== A container for the HistomicsML2 web server is pulled =="
+echo "==========================================================="
+
+docker network create --subnet=172.18.0.0/16 hmlnet
+docker run -d --net hmlnet --ip="172.18.0.5" -t -i -e MYSQL_ROOT_PASSWORD='pass' -e MYSQL_DATABASE='nuclei' -p 3306:3306 --name hmldb cancerdatascience/histomicsml_db:example
+
+echo "=========================================================="
+echo "== A container for the HistomicsML2 database is started =="
+echo "=========================================================="
+
+docker run --net hmlnet -i -t -p 80:80 -p 6379:6379 --link hmldb --name hml cancerdatascience/histomicsml:example /bin/bash

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+redis-server --daemonize yes
+
+echo "========================================"
+echo "== Redis server is successfully loaded =="
+echo "========================================"
+
+service apache2 start
+
+echo "==========================================="
+echo "== Apartch server is successfully loaded =="
+echo "==========================================="
+
+cd /var/www/html/predict-rest-api
+
+python run_model_server.py
+
+echo "===================================================="
+echo "== Model server is disconnected ===================="
+echo "== Run "./restart.sh" to restart the model server =="
+echo "===================================================="
+


### PR DESCRIPTION
Added shell scripts for starting HistomicsML2.

run.sh - download dockers and enters into HistomicsML2 web-server.
start.sh - start HistomicsML2 with Redis and Apache server.
restart.sh - restart HistomicsML2 when disconnected.